### PR TITLE
Fix base URL

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -103,7 +103,7 @@ function BennyApplyFlow(props: Props) {
   );
 
   const url = useMemo(
-    () => `${BASE_URL}?$organizationId=${organizationId}&externalId=${externalId}&isWebView=true`,
+    () => `${BASE_URL}?organizationId=${organizationId}&externalId=${externalId}&isWebView=true`,
     [organizationId, externalId],
   );
 


### PR DESCRIPTION
Before this change, the base URL had an extraneous `$`. This change removes it.