### PR TITLE
Enable NPM in release-it

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
       "tagName": "v${version}"
     },
     "npm": {
-      "publish": false
+      "publish": true
     },
     "github": {
       "release": true


### PR DESCRIPTION
Enables release-it NPM publishing now that 1.0.0 version is released.