### PR TITLE
Use SafeAreaProvider in sample app

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -13,6 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-native": "^0.73.6",
+    "react-native-safe-area-context": "4.8.2",
     "react-native-web": "^0.19.10"
   },
   "devDependencies": {

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -2,33 +2,29 @@ import * as React from 'react';
 
 import { EbtBalanceLinkFlow, EbtBalanceLinkFlowEnvironment } from '@bennyapi/react-native-sdk';
 import {
-  Alert, KeyboardAvoidingView, Platform, SafeAreaView, StyleSheet,
+  Alert, KeyboardAvoidingView,
 } from 'react-native';
+import { SafeAreaProvider, useSafeAreaInsets } from 'react-native-safe-area-context';
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
-  keyboardAvoiding: {
-    flex: 1,
-  },
-});
+export function EbtBalanceLinkFlowContainer() {
+  const insets = useSafeAreaInsets();
+  return (
+    <KeyboardAvoidingView style={{ flex: 1, paddingTop: insets.top }}>
+      <EbtBalanceLinkFlow
+        organizationId="org_wup29bz683g8habsxvazvyz1"
+        temporaryLink="temp_clr0vujq9000108l66odc7fxv"
+        onExit={() => Alert.alert('onExit called')}
+        onLinkSuccess={(linkToken) => Alert.alert(`onLinkSuccess called ${linkToken}`)}
+        environment={EbtBalanceLinkFlowEnvironment.Sandbox}
+      />
+    </KeyboardAvoidingView>
+  );
+}
 
 export default function App() {
   return (
-    <SafeAreaView style={styles.container}>
-      <KeyboardAvoidingView
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        style={styles.keyboardAvoiding}
-      >
-        <EbtBalanceLinkFlow
-          organizationId="org_wup29bz683g8habsxvazvyz1"
-          temporaryLink="temp_clr0vujq9000108l66odc7fxv"
-          onExit={() => Alert.alert('onExit called')}
-          onLinkSuccess={(linkToken) => Alert.alert(`onLinkSuccess called ${linkToken}`)}
-          environment={EbtBalanceLinkFlowEnvironment.Sandbox}
-        />
-      </KeyboardAvoidingView>
-    </SafeAreaView>
+    <SafeAreaProvider>
+      <EbtBalanceLinkFlowContainer />
+    </SafeAreaProvider>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1860,6 +1860,7 @@ __metadata:
     react: ^18.2.0
     react-dom: ^18.2.0
     react-native: ^0.73.6
+    react-native-safe-area-context: 4.8.2
     react-native-web: ^0.19.10
   languageName: unknown
   linkType: soft
@@ -13689,6 +13690,16 @@ __metadata:
   bin:
     bob: bin/bob
   checksum: 1bee701c21f28f10c5737c8000e7fd6d8f641cf46fe7de03f5086d9951d2c5f3cb45375e292519b85f44a28f907e37f6c7bff324cfb1913b3bee0cb4db2efeb7
+  languageName: node
+  linkType: hard
+
+"react-native-safe-area-context@npm:4.8.2":
+  version: 4.8.2
+  resolution: "react-native-safe-area-context@npm:4.8.2"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 929eaa5ee522f712e7bfabd0f22908f033918d030c932ddf6a83e4315bc781f7aa44e315806dc8130f75619f09951f3237082f720f4fa65a6670469886cf9735
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates sample app to use `SafeAreaProvider` to account better for Android devices with cutouts.