### PR TITLE
Add onLinkResult to share more information with client

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,8 +33,8 @@ a `temporarylink` that is generated serverside via a call to the Benny API.
 The Ebt Balance Link Flow is contained in a simple fullscreen component, `EbtBalanceLinkFlow`, that
 is initialized with your organization ID and the single-use temporary link.
 
-Callbacks (i.e., `onExit` and `onLinkSuccess`) are responsible for communicating to your app when the user wants to
-exit the flow and when a link is successful.
+Callbacks (i.e., `onExit` and `onLinkResult`) are responsible for communicating to your app when the user wants to
+exit the flow and when a link result is obtained.
 
 ```typescript jsx
 <EbtBalanceLinkFlow
@@ -43,8 +43,8 @@ exit the flow and when a link is successful.
   onExit={() => {
     /** Your on exit logic. */
   }}
-  onLinkSuccess={
-    /** Your on link success logic. */
+  onLinkResult={
+    /** Your on link result logic. */
   }
   environment={EbtBalanceLinkFlowEnvironment.Sandbox}
 />

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -14,7 +14,7 @@ export function EbtBalanceLinkFlowContainer() {
         organizationId="org_wup29bz683g8habsxvazvyz1"
         temporaryLink="temp_clr0vujq9000108l66odc7fxv"
         onExit={() => Alert.alert('onExit called')}
-        onLinkSuccess={(linkToken) => Alert.alert(`onLinkSuccess called ${linkToken}`)}
+        onLinkResult={(result) => Alert.alert(`onLinkResult called ${JSON.stringify(result)}`)}
         environment={EbtBalanceLinkFlowEnvironment.Sandbox}
       />
     </KeyboardAvoidingView>

--- a/src/ebt-balance/types/ebtBalanceFlowMessage.ts
+++ b/src/ebt-balance/types/ebtBalanceFlowMessage.ts
@@ -1,14 +1,23 @@
+import type { LinkResult } from '@ebt-balance/types/linkResult';
+
 type CopyToClipboardMessage = {
   type: 'CopyToClipboard';
   label: string;
   text: string;
 };
 type ExitMessage = { type: 'Exit' };
+
+type LinkResultMessage = { type: 'LinkResult'; result: LinkResult; };
+
+/**
+ * @deprecated - replaced by {@link LinkResultMessage}
+ */
 type LinkSuccessMessage = { type: 'LinkSuccess'; linkToken: string };
 type OpenUrlExternallyMessage = { type: 'OpenUrlExternally', url: string };
 
 export type EbtBalanceLinkWebAppMessage =
   | ExitMessage
   | CopyToClipboardMessage
+  | LinkResultMessage
   | LinkSuccessMessage
   | OpenUrlExternallyMessage;

--- a/src/ebt-balance/types/linkResult.ts
+++ b/src/ebt-balance/types/linkResult.ts
@@ -1,0 +1,16 @@
+export type LinkResultSuccess = {
+  type: 'LinkResultSuccess';
+  linkToken: string;
+  accountId: string;
+  accountHolder: {
+    name: string | null;
+    address: string | null;
+    balances: {
+      snap: number | null;
+      cash: number | null;
+    };
+    lastTransactionDate: string | null;
+  };
+};
+
+export type LinkResult = LinkResultSuccess;


### PR DESCRIPTION
Introduces `onLinkResult` to replace `onLinkSuccess` and to share more information with SDK consumers beyond the link token.